### PR TITLE
Emmix/shield bash

### DIFF
--- a/RMod/Classes/R_AShield.uc
+++ b/RMod/Classes/R_AShield.uc
@@ -166,7 +166,7 @@ function bool JointDamaged(int Damage, Pawn EventInstigator, vector HitLoc, vect
 	// [RMod]
 	// Cause the owner to enter into HitStun
 	// Copy from Pawn.DamageBodyPart, to avoid modifying Pawn
-	if(Owner != None && Pawn(Owner) != None && CheckIsShieldHitStunEnabled())
+	if(Owner != None && Pawn(Owner) != None && CheckIsShieldHitStunEnabled() && GetStateName() != 'Active')
 	{
 		POwner = Pawn(Owner);
 		if (POwner.GetStateName() != 'Pain' && POwner.GetStateName() != 'pain')
@@ -372,9 +372,25 @@ state Swinging
 		P = Pawn(A);
 		if(P != None && P.GetStateName() != 'Pain' && P.GetStateName() != 'pain')
 		{
+			P.Velocity = P.Velocity * 0.2;
 			P.NextStateAfterPain = P.GetStateName();
 			P.PlayTakeHit(0.1, 50, HitLoc, 'blunt', SweepMomentum, 0);
 			P.GotoState('Pain');
+		}
+		else if(Weapon(A) != None)
+		{
+			HandleSweepCollision_Weapon(Weapon(A), LowMask, HighMask, HitLoc, HitNorm);
+		}
+	}
+	
+	function HandleSweepCollision_Weapon(Weapon W, int LowMask, int HighMask, Vector HitLoc, Vector HitNorm)
+	{
+		// Try to deflect the weapon - Maybe make this auto-target the thrower?
+		if(W.Owner == None)
+		{
+			W.Velocity = -W.Velocity;
+			W.Instigator = Pawn(Owner);
+			W.GotoState('Throw');
 		}
 	}
 }

--- a/RMod/Classes/R_AShield.uc
+++ b/RMod/Classes/R_AShield.uc
@@ -118,6 +118,57 @@ function bool JointDamaged(int Damage, Pawn EventInstigator, vector HitLoc, vect
 	return(false);
 }
 
+/**
+*	StartAttack
+*	Called from R_RunePlayer ShieldActivate function during shield attacks
+*/
+function StartAttack()
+{}
+
+/**
+*	FinishAttack
+*	Called from R_RunePlayer ShieldDeactivate function during shield attacks
+*/
+function FinishAttack()
+{}
+
+/**
+*	PlaySwipeSound
+*	Called from R_RunePlayerProxy ShieldActivate function during shield attacks
+*/
+function PlaySwipeSound()
+{}
+
+/**
+*	ShieldFire
+*	Called from R_RunePlayerProxy ShieldActivate function during shield attacks
+*	Weapon class appears to use this function only for rune power behavior, so
+*	for the moment it does nothing here
+*/
+function ShieldFire()
+{}
+
+/**
+*	State Idle (override)
+*	Shield is currently equipped by the owner
+*/
+state Idle
+{
+	
+}
+
+/**
+*	State Active (override)
+*	Shield is currently equipped by the owner AND it is in the defend state
+*/
+state Active
+{
+	event Tick(float DeltaSeconds)
+	{
+		Super.Tick(DeltaSeconds);
+	}
+}
+
 defaultproperties
 {
 }

--- a/RMod/Classes/R_AShield.uc
+++ b/RMod/Classes/R_AShield.uc
@@ -370,6 +370,10 @@ function Class<Actor> GetHitEffectClassForMatterType(EMatterType MatterType)
 	return Result;
 }
 
+/**
+*	GetHitSoundForMatterType
+*	Helper function that returns the hit sound that corresponds to the matter type struck
+*/
 function Sound GetHitSoundForMatterType(EMatterType MatterType)
 {
 	local Sound Result;

--- a/RMod/Classes/R_ClientDebugActor.uc
+++ b/RMod/Classes/R_ClientDebugActor.uc
@@ -1,0 +1,105 @@
+class R_ClientDebugActor extends Actor;
+
+struct FDebugLineSegment
+{
+	var Vector Begin;
+	var Vector End;
+	var Color Color;
+	var float TimeStampSeconds;
+	var float LifeTimeSeconds;
+};
+var FDebugLineSegment DebugLineSegmentArray[32];
+const DEBUG_LINE_SEGMENT_COUNT = 32;
+
+event BeginPlay()
+{
+	InitializeDebugLineSegmentArray();
+}
+
+function InitializeDebugLineSegmentArray()
+{
+	local int i;
+	
+	for(i = 0; i < DEBUG_LINE_SEGMENT_COUNT; ++i)
+	{
+		DebugLineSegmentArray[i].TimeStampSeconds = 0.0;
+		DebugLineSegmentArray[i].LifeTimeSeconds = 0.0;
+	}
+}
+
+function bool CheckIsLineSegmentIndexActive(int LineSegmentIndex)
+{
+	local float DeltaSeconds;
+	
+	if(LineSegmentIndex >= DEBUG_LINE_SEGMENT_COUNT || LineSegmentIndex < 0)
+	{
+		return false;
+	}
+	
+	DeltaSeconds = Level.TimeSeconds - DebugLineSegmentArray[LineSegmentIndex].TimeStampSeconds;
+	return DeltaSeconds <= DebugLineSegmentArray[LineSegmentIndex].LifeTimeSeconds;
+}
+
+function DrawLineSegmentForDuration(Vector Begin, Vector End, Color Color, float DurationSeconds)
+{
+	local int i;
+	local int LineSegmentIndex;
+	
+	for(i = 0; i < DEBUG_LINE_SEGMENT_COUNT; ++i)
+	{
+		if(!CheckIsLineSegmentIndexActive(i))
+		{
+			break;
+		}
+	}
+	
+	if(i < DEBUG_LINE_SEGMENT_COUNT)
+	{
+		DebugLineSegmentArray[i].Begin = Begin;
+		DebugLineSegmentArray[i].End = End;
+		DebugLineSegmentArray[i].Color = Color;
+		DebugLineSegmentArray[i].TimeStampSeconds = Level.TimeSeconds;
+		DebugLineSegmentArray[i].LifeTimeSeconds = DurationSeconds;
+	}
+}
+
+event PostRender(Canvas C)
+{
+	RenderDebugLineSegments(C);
+}
+
+event RenderDebugLineSegments(Canvas C)
+{
+	local int i;
+	local FDebugLineSegment DebugLineSegment;
+	local Vector BoxExtents;
+	
+	BoxExtents.X = 8.0;
+	BoxExtents.Y = 8.0;
+	BoxExtents.Z = 8.0;
+	for(i = 0; i < DEBUG_LINE_SEGMENT_COUNT; ++i)
+	{
+		if(CheckIsLineSegmentIndexActive(i))
+		{
+			DebugLineSegment = DebugLineSegmentArray[i];
+			C.DrawLine3D(
+				DebugLineSegment.Begin,
+				DebugLineSegment.End,
+				DebugLineSegment.Color.R,
+				DebugLineSegment.Color.G,
+				DebugLineSegment.Color.B);
+			C.DrawBox3D(
+				DebugLineSegment.Begin,
+				BoxExtents,
+				DebugLineSegment.Color.R,
+				DebugLineSegment.Color.G,
+				DebugLineSegment.Color.B);
+		}
+	}
+}
+
+defaultproperties
+{
+	RemoteRole=ROLE_None
+	DrawType=DT_None
+}

--- a/RMod/Classes/R_RunePlayer.uc
+++ b/RMod/Classes/R_RunePlayer.uc
@@ -67,11 +67,34 @@ replication
 		ServerResetLevel,
 		ServerSwitchGame,
 		ServerSpectate,
-		ServerTimeLimit;
+		ServerTimeLimit,
+		ServerTestCombo;
 		
 	unreliable if(Role == ROLE_Authority && RemoteRole != ROLE_AutonomousProxy)
 		ViewRotPovPitch,
 		ViewRotPovYaw;
+}
+
+exec function TestCombo()
+{
+	if(Role < ROLE_Authority)
+	{
+		DoTestCombo();
+	}
+	else
+	{
+		ServerTestCombo();
+	}
+}
+
+function ServerTestCombo()
+{
+	DoTestCombo();
+}
+
+function DoTestCombo()
+{
+	AnimProxy.GotoState('ComboAttack');
 }
 
 /**
@@ -1363,6 +1386,56 @@ simulated function DoTryPlayTorsoAnim(Name TorsoAnim, float speed, float tween)
 	}
 
 	Super.DoTryPlayTorsoAnim(TorsoAnim, speed, tween);
+}
+
+/**
+*	WeaponActivate (override)
+*	Called from AnimProxy Attack functions
+*/
+function WeaponActivate()
+{
+	if(Weapon != None)
+	{
+		Weapon.StartAttack();
+	}
+}
+
+/**
+*	WeaponDeactivate (override)
+*	Called from AnimProxy Attack functions
+*/
+function WeaponDeactivate()
+{
+    if(Weapon != None)
+    {
+        Weapon.FinishAttack();
+    }
+}
+
+/**
+*	ShieldActivate
+*	Called from R_RunePlayerProxy Attack functions
+*	New function that enables collision for shield bash attack
+*/
+function ShieldActivate()
+{
+	if(R_AShield(Shield) != None)
+	{
+		R_AShield(Shield).StartAttack();
+	}
+}
+
+/**
+*	ShieldDeactivate
+*	Called from R_RunePlayerProxy Attack functions
+*	New function that disables collision for shield bash attack
+*/
+function ShieldDeactivate()
+{
+	if(R_AShield(Shield) != None)
+	{
+		R_AShield(Shield).FinishAttack();
+	}
 }
 
 /**

--- a/RMod/Classes/R_RunePlayerProxy.uc
+++ b/RMod/Classes/R_RunePlayerProxy.uc
@@ -1,5 +1,262 @@
 class R_RunePlayerProxy extends RunePlayerProxy;
 
+/**
+*	EAttackType
+*	Enumerator for keeping track of what the player is attacking with while
+*	inside of the attack state
+*/
+enum EAttackType
+{
+	AT_None,			// No current attack
+	AT_WeaponAttack,	// Attacking with weapon
+	AT_ShieldAttack		// Attacking with shield
+};
+var EAttackType CurrentAttackType;
+
+var Name PendingRecoveryAnimation;
+
+function SetCurrentAttackType(EAttackType AttackType)
+{
+	CurrentAttackType = AttackType;
+}
+
+/**
+*	ShieldActivate
+*	Called from attack state when the shield is used to perform an attack
+*/
+function ShieldActivate()
+{
+	local R_RunePlayer RPOwner;
+	local R_AShield OwnerShield;
+	
+	RPOwner = R_RunePlayer(Owner);
+	if(RPOwner != None)
+	{
+		OwnerShield = R_AShield(RPOwner.Shield);
+		if(OwnerShield != None)
+		{
+			RPOwner.ShieldActivate();
+			OwnerShield.PlaySwipeSound();
+			OwnerShield.ShieldFire();
+		}
+	}
+}
+
+function ShieldDeactivate()
+{
+	local R_RunePlayer RPOwner;
+	local R_AShield OwnerShield;
+	
+	RPOwner = R_RunePlayer(Owner);
+	if(RPOwner != None)
+	{
+		OwnerShield = R_AShield(RPOwner.Shield);
+		if(OwnerShield != None)
+		{
+			RPOwner.ShieldDeactivate();
+		}
+	}
+}
+
+auto state Idle
+{
+	/**
+	*	Attack (override)
+	*	Overridden to update attack state when triggered
+	*/
+	function bool Attack()
+	{
+		local bool bResult;
+		
+		SetCurrentAttackType(AT_WeaponAttack);
+		bResult = Super.Attack();
+		
+		// If super failed, reset attack state
+		if(!bResult)
+		{
+			SetCurrentAttackType(AT_None);
+		}
+		
+		return bResult;
+	}
+}
+
+state Defending
+{
+	/**
+	*	Attack (override)
+	*	Player wants to attack from the shield defend state, so perform a shield bash
+	*/
+	function bool Attack()
+	{
+		
+		SetCurrentAttackType(AT_ShieldAttack);
+		TorsoAnim = 'H3_DefendAttack';
+		GotoState('Attacking');
+		return true;
+	}
+}
+
+/**
+*	SwipeEffectStart (override)
+*	Overridden to enable swipe effect based on attack type
+*/
+function SwipeEffectStart()
+{
+	switch(CurrentAttackType)
+	{
+	case AT_WeaponAttack:
+		// TODO: Enable weapon swipe
+		break;
+		
+	case AT_ShieldAttack:
+		// TODO: Enable shield swipe
+		break;
+	}
+}
+
+/**
+*	SwipeEffectEnd (override)
+*	Overridden to disable swipe effect based on attack type
+*/
+function SwipeEffectEnd()
+{
+	switch(CurrentAttackType)
+	{
+	case AT_WeaponAttack:
+		// TODO: Disable weapon swipe
+		break;
+		
+	case AT_ShieldAttack:
+		// TODO: Disable shield swipe
+		break;
+	}
+}
+
+state Attacking
+{
+	event BeginState()
+	{
+		SwipeEffectStart();
+	}
+	
+	event EndState()
+	{
+		// Make sure that both shield and weapon attack are disabled
+		WeaponDeactivate();
+		ShieldDeactivate();
+		SwipeEffectEnd();
+		SetCurrentAttackType(AT_None);
+	}
+	
+	/**
+	*	StopAttack (override)
+	*	Overridden to disable shield attack
+	*/
+	function StopAttack()
+	{
+		WeaponDeactivate();
+		ShieldDeactivate();
+		SyncAnimation(0.3);
+		SwipeEffectEnd();
+		SetCurrentAttackType(AT_None);
+		
+		GotoState('Idle');
+	}
+	
+	/**
+	*	SelectRecoveryAnimationForAttackAnimation
+	*	Async attack code gets the recovery animation from this function for each attack
+	*/
+	function Name SelectRecoveryAnimationForAttackAnimation(Name AttackAnimation)
+	{
+		local R_RunePlayer RPOwner;
+		local Weapon OwnerWeapon;
+		
+		RPOwner = R_RunePlayer(Owner);
+		if(RPOwner != None)
+		{
+			if(CurrentAttackType == AT_WeaponAttack)
+			{
+				OwnerWeapon = RPOwner.Weapon;
+				if(OwnerWeapon != None)
+				{
+					switch(AttackAnimation)
+					{
+					// Forward attacks
+					case OwnerWeapon.A_AttackA:	return OwnerWeapon.A_AttackAReturn;
+					case OwnerWeapon.A_AttackB:	return OwnerWeapon.A_AttackBReturn;
+					case OwnerWeapon.A_AttackC:	return OwnerWeapon.A_AttackCReturn;
+					case OwnerWeapon.A_AttackD:	return OwnerWeapon.A_AttackDReturn;
+					
+					// Neutral attacks
+					case OwnerWeapon.A_AttackStandA:	return OwnerWeapon.A_AttackStandAReturn;
+					case OwnerWeapon.A_AttackStandB:	return OwnerWeapon.A_AttackStandBReturn;
+					
+					// Back attacks
+					case OwnerWeapon.A_AttackBackupA:	return OwnerWeapon.A_AttackBackupAReturn;
+					case OwnerWeapon.A_AttackBackupB:	return OwnerWeapon.A_AttackBackupBReturn;
+					}
+				}
+			}
+		}
+		
+		return 'None';
+	}
+
+Begin:
+	if(CurrentAttackType == AT_WeaponAttack)
+	{
+		goto('DoWeaponAttack');
+	}
+	else if(CurrentAttackType == AT_ShieldAttack)
+	{
+		goto('DoShieldAttack');
+	}
+
+/**
+*	Cleanup of original weapon combo attack async code
+*/
+DoWeaponAttack:
+	PlayAttack(0.1);
+	Sleep(0.1);
+	WeaponActivate();
+	PendingRecoveryAnimation = SelectRecoveryAnimationForAttackAnimation(TorsoAnim);
+	TorsoAnim = 'None';
+	FinishAnim();
+	WeaponDeactivate();
+DoComboWeaponAttack:
+	if(TorsoAnim != 'None')
+	{
+		PlayAttack(0.0);
+		PendingRecoveryAnimation = SelectRecoveryAnimationForAttackAnimation(TorsoAnim);
+		TorsoAnim = 'None';
+		FinishAnim();
+		WeaponDeactivate();
+		goto('DoComboWeaponAttack');
+	}
+DoWeaponRecovery:
+	if(PendingRecoveryAnimation != 'None')
+	{
+		TorsoAnim = PendingRecoveryAnimation;
+		PlayAttack(0.0);
+		TorsoAnim = 'None';
+		FinishAnim();
+	}
+	goto('Done');
+
+/**
+*	New shield attack async code
+*/
+DoShieldAttack:
+	goto('Done');
+
+Done:
+	SyncAnimation(0.01);
+	GotoState('Idle');
+}
+
 defaultproperties
 {
+	//ComboSpeed=1.5
 }

--- a/RMod_FreezeTag/Classes/R_RunePlayer_FreezeTag.uc
+++ b/RMod_FreezeTag/Classes/R_RunePlayer_FreezeTag.uc
@@ -415,7 +415,6 @@ state Frozen extends PlayerWalking
 
         //ApplyStatueFeatures();
         bSweepable = false;
-        bForceClientAdjustPosition = true;
 
         PlaySound(Sound'WeaponsSnd.Powerups.atfreezeice01', SLOT_Interface, 0.75);
 
@@ -457,7 +456,6 @@ state Frozen extends PlayerWalking
         bSweepable = true;
         DestroyIceStatueProxy();
         RemoveStatueFeatures();
-        bForceClientAdjustPosition = true;
 
         PlaySound(Sound'WeaponsSnd.impcrashes.crashglass02', SLOT_Pain, 0.35);
         SpawnDebris();


### PR DESCRIPTION
Implemented shield bash attack for the R_RunePlayer class.

Original game files included an animation named 'H3_DefendAttack', which depicts the player performing a shield bash attack. The original game code never implemented this mechanic.

Through modifying R_RunePlayer, R_RunePlayerProxy, and R_AShield, shields now are capable of performing collision detection similar to weapons, and the player can trigger a shield bash attack by holding defend (alt fire) and pressing the attack button. Previously, this was an unused function.