### PR TITLE
[Bug Fix] RMod.R_AWeapon_BodyPart.Drop.EndState:001D (Accessed None)

### DIFF
--- a/RMod/Classes/R_AWeapon_BodyPart.uc
+++ b/RMod/Classes/R_AWeapon_BodyPart.uc
@@ -116,7 +116,6 @@ auto state Pickup
 Begin: // Overridden to avoid overwriting subclass settings
 }
 
-
 state Drop
 {
     function BeginState()
@@ -134,13 +133,20 @@ state Drop
         //DesiredRotation.Yaw = Rotation.Yaw - Rand(2000) + 1000;     
     }
     
-    function EndState()
-    {
-        Super.EndState();
+	function EndState()
+	{
+		Super.EndState();
 
-        Blood = DetachActorFromJoint(JointNamed('offset'));
-        Blood.Destroy();        
-    }
+		if (Blood != None)
+		{
+			Blood = DetachActorFromJoint(JointNamed('offset'));
+
+			if (Blood != None)
+			{
+				Blood.Destroy();
+			}
+		}
+	}
     
     function InitializeStateRotation()
     {


### PR DESCRIPTION
Fix a rare case where Destroy() is called on None when a limb has fallen out of the world and no longer exists.

> R_Weapon_BodyPart_Limb1159 fell out of the world!
> R_Weapon_BodyPart_Limb DM-Hildir.R_Weapon_BodyPart_Limb1159 (Function RMod.R_AWeapon_BodyPart.Drop.EndState:001D) Accessed None