### PR TITLE
[Bug Fix] R_RunePlayer.PlayerSpectating.EndState (Client Crash)

### DIFF
--- a/RMod/Classes/R_RunePlayer.uc
+++ b/RMod/Classes/R_RunePlayer.uc
@@ -3410,9 +3410,9 @@ state PlayerSpectating
 		Self.SetCollision(true, true, true);
 		Self.bCollideWorld = Self.Default.bCollideWorld;
 		Self.DrawType = Self.Default.DrawType;
-		Self.bHidden = Self.Default.bHidden;
+		//Self.bHidden = Self.Default.bHidden;
 		Self.bAlwaysRelevant = Self.Default.bAlwaysRelevant;
-		Self.PlayerReplicationInfo.bIsSpectator = false;
+		//Self.PlayerReplicationInfo.bIsSpectator = false;
 
 		if (Role == ROLE_Authority)
 		{

--- a/RMod/Classes/R_RunePlayer.uc
+++ b/RMod/Classes/R_RunePlayer.uc
@@ -3405,23 +3405,28 @@ state PlayerSpectating
         }
     }
 
-    event EndState()
-    {
-        Self.SetCollision(true, true, true);
-        Self.bCollideWorld = Self.Default.bCollideWorld;
-        Self.DrawType = Self.Default.DrawType;
-        //Self.bHidden = Self.Default.bHidden;
-        Self.bAlwaysRelevant = Self.Default.bAlwaysRelevant;
-        //Self.PlayerReplicationInfo.bIsSpectator = false;
+	event EndState()
+	{
+		Self.SetCollision(true, true, true);
+		Self.bCollideWorld = Self.Default.bCollideWorld;
+		Self.DrawType = Self.Default.DrawType;
+		Self.bHidden = Self.Default.bHidden;
+		Self.bAlwaysRelevant = Self.Default.bAlwaysRelevant;
+		Self.PlayerReplicationInfo.bIsSpectator = false;
 
-        if(Role == ROLE_Authority)
-        {
-            if(Camera != None)
-            {
-                Camera.Destroy();
-            }
-        }
-    }
+		if (Role == ROLE_Authority)
+		{
+			if (Camera != None && !Camera.bDeleteMe)
+			{
+				Camera.Destroy();
+				Camera = None;
+			}
+			else
+			{
+				Camera = None;
+			}
+		}
+	}
     
     event PlayerCalcView(
         out Actor ViewActor,


### PR DESCRIPTION
Fix crash in EndState() by safely checking Camera before calling Destroy().

> Critical Error
> 
> General protection fault!
> 
> History: UObject::ProcessEvent <- (R_RunePlayer DM-Bothvar.R_RunePlayer0, Function RMod.R_RunePlayer.PlayerSpectating.EndState)
> <- EndState <- ULevel::DestroyActor <- (R_RunePlayer DM-Bothvar.R_RunePlayer0)
> <- UPlayer::Destroy <- UNetConnection::Destroy <- UObject::ConditionalDestroy <- (TcpipConnection Transient.TcpipConnection0)
> <- UChannel::RouteDestroy <- UActorChannel::Destroy <- UObject::ConditionalDestroy <- (ActorChannel Transient.ActorChannel0)
> <- DispatchDestroy <- DispatchDestroys <- ULevel::PurgeGarbage <- UObject::CollectGarbage <- Cleanup <- UGameEngine::LoadMap
> <- AttemptLoadPending <- TickPending <- UGameEngine::Tick <- UpdateWorld <- MainLoop