### PR TITLE
[RBots Bug Fix] Skip OnNavMeshNodeIndexChanged for invalid node index

### DIFF
--- a/RBots/Classes/R_Bot.uc
+++ b/RBots/Classes/R_Bot.uc
@@ -586,7 +586,8 @@ function UpdateNavContext(float DeltaSeconds)
 		// Fire events if necessary
 		if(ActiveBehavior != None)
 		{
-			if(NodeIndex != OldNodeIndex)
+			// Only trigger if NodeIndex is valid
+			if(NodeIndex != NavLib.Static.InvalidIndex() && NodeIndex != OldNodeIndex)
 			{
 				OnNavMeshNodeIndexChanged(OldNodeIndex, NodeIndex);
 			}


### PR DESCRIPTION
Added a check to ensure OnNavMeshNodeIndexChanged is only called when the new node index is valid (not -1), avoiding errors from GetTriangleNeighborSetUnchecked with an invalid index.

> Function RBots.R_NavMesh_Implementation.GetTriangleNeighborSetUnchecked:0019 Accessed array out of bounds (-1/10000)