### PR TITLE
Add null checks to DestroyPawnsWeapons function to prevent crashes when player leaves mid-game

### DIFF
--- a/RMod_Arena/Classes/R_GameInfo_Arena.uc
+++ b/RMod_Arena/Classes/R_GameInfo_Arena.uc
@@ -1703,6 +1703,9 @@ function DestroyPawnsWeapons(Pawn PlayerPawn)
 	local Inventory next;
 	local int i;
 
+	if (PlayerPawn == None || PlayerPawn.Inventory == None)
+		return;
+
 	i = 0;
 	
 	for(Inv = PlayerPawn.Inventory; Inv != None; Inv = next)


### PR DESCRIPTION
Added null checks for PlayerPawn and PlayerPawn.Inventory to prevent potential crashes when the player has no inventory or the pawn is invalid.

Ensured safe iteration through inventory by checking for null before accessing or modifying inventory items.

Prevented possible issues when setting Weapon and SelectedItem to None.

> ArenaGameInfo AR-8on8-LavaPit.ArenaGameInfo0 (Function RMod.R_GameInfo_Arena.DestroyPawnsWeapons:0013) Accessed None
> ArenaGameInfo AR-8on8-LavaPit.ArenaGameInfo0 (Function RMod.R_GameInfo_Arena.DestroyPawnsWeapons:005B) Accessed None
> ArenaGameInfo AR-8on8-LavaPit.ArenaGameInfo0 (Function RMod.R_GameInfo_Arena.DestroyPawnsWeapons:0063) Attempt to assigned variable through None
> ArenaGameInfo AR-8on8-LavaPit.ArenaGameInfo0 (Function RMod.R_GameInfo_Arena.DestroyPawnsWeapons:006B) Accessed None
> ArenaGameInfo AR-8on8-LavaPit.ArenaGameInfo0 (Function RMod.R_GameInfo_Arena.DestroyPawnsWeapons:0073) Attempt to assigned variable through None